### PR TITLE
feat: transform neovim into devops-ready ide

### DIFF
--- a/IDE_GUIDE.md
+++ b/IDE_GUIDE.md
@@ -1,0 +1,35 @@
+# Neovim IDE Guide
+
+This configuration turns Neovim into a full-featured IDE with a focus on Go, DevOps tools, and modern front-end languages.
+
+## Key Shortcuts
+
+| Mapping | Mode | Description |
+| --- | --- | --- |
+| `<C-s>` / `<D-s>` | normal/insert/visual | Save current file |
+| `<leader>tt` | normal | Toggle floating terminal |
+| `<leader>tn` | normal | Run nearest test |
+| `<leader>tf` | normal | Run all tests in file |
+| `<leader>ts` | normal | Run full test suite |
+
+## Language Support
+
+- Go via `gopls` and `go.nvim`
+- Terraform (`terraformls`)
+- Ansible (`ansiblels`)
+- JSON & YAML
+- JavaScript/TypeScript, HTML, CSS
+
+## DevOps Helpers
+
+- `toggleterm.nvim` provides a floating terminal for running tools like Terraform and Ansible directly inside Neovim.
+- `vim-test` integrates with the terminal to run tests.
+- `nvim-lint` runs linters on save for Go, Terraform, YAML, Ansible, and JSON.
+
+## Tips & Tricks
+
+- Use `jk` in insert mode to quickly exit to normal mode.
+- `;` in normal mode enters command mode.
+- Remember that many NvChad defaults (file explorer, fuzzy finder, statusline) are available out of the box.
+
+Happy hacking!

--- a/lua/configs/conform.lua
+++ b/lua/configs/conform.lua
@@ -1,6 +1,13 @@
 local options = {
   formatters_by_ft = {
     lua = { "stylua" },
+    go = { "gofmt" },
+    terraform = { "terraform_fmt" },
+    hcl = { "terraform_fmt" },
+    json = { "prettier" },
+    yaml = { "prettier" },
+    javascript = { "prettier" },
+    typescript = { "prettier" },
     -- css = { "prettier" },
     -- html = { "prettier" },
   },

--- a/lua/configs/lint.lua
+++ b/lua/configs/lint.lua
@@ -1,0 +1,16 @@
+local lint = require("lint")
+
+lint.linters_by_ft = {
+  go = { "golangci-lint" },
+  terraform = { "tflint" },
+  hcl = { "tflint" },
+  yaml = { "yamllint" },
+  ansible = { "ansible-lint" },
+  json = { "jsonlint" },
+}
+
+vim.api.nvim_create_autocmd({ "BufWritePost" }, {
+  callback = function()
+    lint.try_lint()
+  end,
+})

--- a/lua/configs/lspconfig.lua
+++ b/lua/configs/lspconfig.lua
@@ -1,6 +1,16 @@
 require("nvchad.configs.lspconfig").defaults()
 
-local servers = { "html", "cssls" }
+local servers = {
+  "html",
+  "cssls",
+  "tsserver",
+  "jsonls",
+  "yamlls",
+  "gopls",
+  "terraformls",
+  "ansiblels",
+}
+
 vim.lsp.enable(servers)
 
 -- read :h vim.lsp.config for changing options of lsp servers 

--- a/lua/configs/test.lua
+++ b/lua/configs/test.lua
@@ -1,0 +1,1 @@
+vim.g["test#strategy"] = "toggleterm"

--- a/lua/configs/toggleterm.lua
+++ b/lua/configs/toggleterm.lua
@@ -1,0 +1,9 @@
+local tt = require("toggleterm")
+
+tt.setup {
+  direction = "float",
+  float_opts = {
+    border = "curved",
+  },
+  start_in_insert = true,
+}

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -7,4 +7,11 @@ local map = vim.keymap.set
 map("n", ";", ":", { desc = "CMD enter command mode" })
 map("i", "jk", "<ESC>")
 
--- map({ "n", "i", "v" }, "<C-s>", "<cmd> w <cr>")
+map({ "n", "i", "v" }, "<C-s>", "<cmd>w<cr>", { desc = "Save file" })
+map({ "n", "i", "v" }, "<D-s>", "<cmd>w<cr>", { desc = "Save file" })
+
+map("n", "<leader>tt", "<cmd>ToggleTerm direction=float<cr>", { desc = "Toggle terminal" })
+
+map("n", "<leader>tn", "<cmd>TestNearest<cr>", { desc = "Run nearest test" })
+map("n", "<leader>tf", "<cmd>TestFile<cr>", { desc = "Run file tests" })
+map("n", "<leader>ts", "<cmd>TestSuite<cr>", { desc = "Run test suite" })

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -13,6 +13,61 @@ return {
     end,
   },
 
+  {
+    "akinsho/toggleterm.nvim",
+    version = "*",
+    config = function()
+      require "configs.toggleterm"
+    end,
+  },
+
+  {
+    "vim-test/vim-test",
+    config = function()
+      require "configs.test"
+    end,
+  },
+
+  {
+    "ray-x/go.nvim",
+    ft = { "go", "gomod", "gosum", "gowork" },
+    dependencies = { "ray-x/guihua.lua" },
+    build = ':lua require("go.install").update_all_sync()',
+    config = function()
+      require("go").setup()
+    end,
+  },
+
+  { "hashivim/vim-terraform", ft = { "terraform", "hcl" } },
+
+  { "pearofducks/ansible-vim", ft = { "yaml", "ansible" } },
+
+  {
+    "mfussenegger/nvim-lint",
+    config = function()
+      require "configs.lint"
+    end,
+  },
+
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      opts.ensure_installed = vim.list_extend(opts.ensure_installed or {}, {
+        "go",
+        "gomod",
+        "gosum",
+        "gowork",
+        "json",
+        "yaml",
+        "terraform",
+        "hcl",
+        "typescript",
+        "tsx",
+        "javascript",
+      })
+    end,
+  },
+
   -- test new blink
   -- { import = "nvchad.blink.lazyspec" },
 


### PR DESCRIPTION
## Summary
- add toggleable floating terminal, Go helpers, linting, testing and DevOps tooling
- wire up LSPs and formatters for Go, Terraform, Ansible, JSON, YAML and web dev
- document new shortcuts and capabilities for the IDE

## Testing
- `nvim --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c51c96a3b483329103236b0bfdb10d